### PR TITLE
Move to blocking flush

### DIFF
--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkWriter.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkWriter.java
@@ -106,8 +106,7 @@ class SnowflakeSinkWriter<IN> implements SinkWriter<IN> {
     }
 
     @Override
-    public void write(IN element, Context context)
-            throws IOException, InterruptedException {
+    public void write(IN element, Context context) throws IOException, InterruptedException {
 
         /*
          * Send to the service for eventual write

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
@@ -181,14 +181,16 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
                 ((CompletableFuture<?>) flushRes).get();
                 LOGGER.info("Successfully flushed channel '{}'", this.getChannelName());
             } catch (InterruptedException | ExecutionException e) {
-                // TODO reopen channel: https://github.com/deltastreaminc/flink-connector-snowflake/issues/11
+                // TODO reopen channel:
+                // https://github.com/deltastreaminc/flink-connector-snowflake/issues/11
                 LOGGER.warn(
                         "Snowflake channel flush did not finish successfully;"
                                 + "Flush will happen within the next buffer time of {}ms",
                         this.getWriterConfig().getMaxBufferTimeMs());
             }
         } else {
-            // TODO reopen channel: https://github.com/deltastreaminc/flink-connector-snowflake/issues/11
+            // TODO reopen channel:
+            // https://github.com/deltastreaminc/flink-connector-snowflake/issues/11
             LOGGER.warn(
                     "Snowflake channel flush did not return a handle to wait on: got {};"
                             + "Flush will happen within the next buffer time of {}ms",


### PR DESCRIPTION
Fixes #6 

Successfully wrote 1000s of records with 15 checkpoints to Snowflake using the `SnowflakeSinkITCase` integration.