### PR TITLE
Fix key passphrase config name when connecting to snowflake with encrypted private key

### DIFF
--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkBuilder.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkBuilder.java
@@ -17,6 +17,7 @@
 
 package io.deltastream.flink.connector.snowflake.sink;
 
+import net.snowflake.ingest.utils.Constants;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.connector.base.DeliveryGuarantee;
@@ -40,11 +41,11 @@ import java.util.Properties;
 @PublicEvolving
 public class SnowflakeSinkBuilder<IN> {
 
-    static final String SNOWFLAKE_URL_CONFIG_NAME = "url";
-    static final String SNOWFLAKE_USER_CONFIG_NAME = "user";
-    static final String SNOWFLAKE_ROLE_CONFIG_NAME = "role";
-    static final String SNOWFLAKE_PRIVATE_KEY_CONFIG_NAME = "private_key";
-    static final String SNOWFLAKE_KEY_PASSPHRASE_CONFIG_NAME = "snowflake.private.key.passphrase";
+    static final String SNOWFLAKE_URL_CONFIG_NAME = Constants.ACCOUNT_URL;
+    static final String SNOWFLAKE_USER_CONFIG_NAME = Constants.USER;
+    static final String SNOWFLAKE_ROLE_CONFIG_NAME = Constants.ROLE;
+    static final String SNOWFLAKE_PRIVATE_KEY_CONFIG_NAME = Constants.PRIVATE_KEY;
+    static final String SNOWFLAKE_KEY_PASSPHRASE_CONFIG_NAME = Constants.PRIVATE_KEY_PASSPHRASE;
 
     /**
      * At minimum, needs to include the required properties as documented by Snowflake: <a

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkBuilder.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkBuilder.java
@@ -17,7 +17,6 @@
 
 package io.deltastream.flink.connector.snowflake.sink;
 
-import net.snowflake.ingest.utils.Constants;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.connector.base.DeliveryGuarantee;
@@ -29,6 +28,7 @@ import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeChannelConf
 import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeWriterConfig;
 import io.deltastream.flink.connector.snowflake.sink.serialization.SnowflakeRowSerializationSchema;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
+import net.snowflake.ingest.utils.Constants;
 
 import java.util.List;
 import java.util.Properties;


### PR DESCRIPTION
The snowflake configuration for private key passphrase was incorrectly documented in Snowpipe Streaming docs (https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-configuration). See screenshot of their docs below:
<img width="1728" alt="Screenshot 2023-11-14 at 6 02 46 PM" src="https://github.com/deltastreaminc/flink-connector-snowflake/assets/19534977/5ca891a6-f8d5-4fde-85d4-1a26dc8bee70">

The `snowflake.private.key.passphrase` configuration was not being respected. When debugging, we noticed that the actual configuration is `private_key_passphrase`.

This change updates to use the values in the Snowpipe API Constants class and subsequently fixes the issues with authentication with an encrypted private key.