### PR TITLE
Upgrade ingest SDK version and configuration restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ class test {
 
 In Snowflake, the full name of a table is case-insensitive, but UPPER_CASE biased. In other words, a sink configured with a fully qualified name of `DB.SCHEMA.table` is treated as `DB.SCHEMA.TABLE`. To be able to use case-sensitive name parts, add double quotes around them to be treated as the literal name, e.g. `DB.SCHEMA."table"`.
 
+## Checkpointing with Flink
+
+It's highly recommended that any checkpointing that happens using this connector to be configured to be at least 1 second to properly [optimize cost and performance](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-streaming-recommendation).
+
 ## Testing
 
 ### Required Credentials

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/config/SnowflakeWriterConfig.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/config/SnowflakeWriterConfig.java
@@ -35,7 +35,7 @@ public final class SnowflakeWriterConfig implements Serializable {
 
     // buffer flush minimum and default
     public static final long BUFFER_FLUSH_TIME_MILLISECONDS_DEFAULT = 1000;
-    public static final long BUFFER_FLUSH_TIME_MILLISECONDS_MIN = 10;
+    public static final long BUFFER_FLUSH_TIME_MILLISECONDS_MIN = 1000;
 
     private final DeliveryGuarantee deliveryGuarantee;
     private final long maxBufferTimeMs;

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<kryo.version>2.24.0</kryo.version>
 		<objenesis.version>2.1</objenesis.version>
 
-		<snowflake-ingest.version>2.0.3</snowflake-ingest.version>
+		<snowflake-ingest.version>2.0.4</snowflake-ingest.version>
 		<failsafe.version>3.3.2</failsafe.version>
 		<assertj.version>3.21.0</assertj.version>
 		<junit5.version>5.10.0</junit5.version>


### PR DESCRIPTION
Fixes #19 

Upgrade the version of the Snowflake ingest SDK and move to 1 sec minimum flush buffer time to avoid putting pressure on the Snowflake tables' backend.

- Upgraded ingest SDK
- Moved to 1 second minimum flush time
- Added document around checkpointing interval best practice

No new logic, and IT writes to Snowflake successfully.
