### PR TITLE
Upgrade to Flink 1.18, validating Java 17 execution

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -8,6 +8,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java:
+          - 17
     permissions:
       contents: read
       packages: write
@@ -17,10 +21,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: ${{ matrix.java }}
         distribution: 'temurin'
         server-id: ossrh
         server-username: MAVEN_USERNAME

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -12,6 +12,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java:
+          - 17
     permissions:
       contents: read
       packages: write
@@ -22,10 +26,10 @@ jobs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: ${{ matrix.java }}
         distribution: 'temurin'
 
     - name: Test and Build Artifact

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeInternalUtils.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeInternalUtils.java
@@ -17,8 +17,8 @@
 
 package io.deltastream.flink.connector.snowflake.sink.internal;
 
-import org.apache.flink.shaded.guava30.com.google.common.base.Joiner;
-import org.apache.flink.shaded.guava30.com.google.common.base.Preconditions;
+import org.apache.flink.shaded.guava31.com.google.common.base.Joiner;
+import org.apache.flink.shaded.guava31.com.google.common.base.Preconditions;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
@@ -25,7 +25,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
 import dev.failsafe.Failsafe;
 import dev.failsafe.Fallback;

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeStreamingIngestClientProvider.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeStreamingIngestClientProvider.java
@@ -20,7 +20,7 @@ package io.deltastream.flink.connector.snowflake.sink.internal;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Maps;
+import org.apache.flink.shaded.guava31.com.google.common.collect.Maps;
 
 import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeWriterConfig;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;

--- a/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkITCase.java
+++ b/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkITCase.java
@@ -6,7 +6,7 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Maps;
+import org.apache.flink.shaded.guava31.com.google.common.collect.Maps;
 
 import io.deltastream.flink.connector.snowflake.sink.context.SnowflakeSinkContext;
 import io.deltastream.flink.connector.snowflake.sink.serialization.SnowflakeRowSerializationSchema;

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 	<properties>
 		<revision>1.0-SNAPSHOT</revision>
 
-		<flink.version>1.17.0</flink.version>
+		<flink.version>1.18.0</flink.version>
 		<kryo.version>2.24.0</kryo.version>
 		<objenesis.version>2.1</objenesis.version>
 


### PR DESCRIPTION
## What is the purpose of the change

Move to Flink 1.18 as the base module and upgrade the dependant packages. This change is also validating that the connector works on Java 17 using the [Java 17 guidelines with Flink 1.18](https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/deployment/java_compatibility/#jdk-modularization). Testing details below.

## Brief change log

- Moved to `flink.version` of `1.18.0`
- Moved to `guava31` packaged with Flink 1.18
- Upgrade CI workflows to Java 17

## Verifying this change

Dependency updates were validated using integration test with the Snowflake service. In the tests these JRE options were added to allow reflection with Flink 1.18: `--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.math=ALL-UNNAMED --add-opens java.base/java.time=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.text=ALL-UNNAMED`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects delivery guarantees: write, flush, buffering, etc.: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
