### PR TITLE
Fix Java 17 shading with parent POM

### DIFF
--- a/flink-connector-snowflake/pom.xml
+++ b/flink-connector-snowflake/pom.xml
@@ -151,6 +151,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>shade-flink</id>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
 	<properties>
 		<revision>1.0-SNAPSHOT</revision>
 
+		<!-- Java versions -->
+		<java.version>17</java.version>
+		<maven.compiler.release>${java.version}</maven.compiler.release>
+		<target.java.version>${java.version}</target.java.version>
+
 		<flink.version>1.18.0</flink.version>
 		<kryo.version>2.24.0</kryo.version>
 		<objenesis.version>2.1</objenesis.version>
@@ -74,6 +79,9 @@
 
 		<checksum-maven-plugin.version>1.11</checksum-maven-plugin.version>
 		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
+		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+		<maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
+
 	</properties>
 
 	<modules>
@@ -365,10 +373,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>11</source>
-					<target>11</target>
-				</configuration>
+				<version>${maven-compiler-plugin.version}</version>
 			</plugin>
 
 			<plugin>
@@ -386,6 +391,25 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-maven</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<!-- maven version must be at least 3.2.5 -->
+									<version>[3.2.5,)</version>
+								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>17</version>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
Related to #21 

## What is the purpose of the change

Moved enforcer and shade plugins to their latest versions to allow for Java 17 enforcement and compilation compatibility, respectively.

## Brief change log

- Moved to Java 17 version enforcement at compilation
- Upgraded shade plugin to fix issues with Java 17 compiled classes
- Upgraded compiler plugin to print out the actual release/target Java version used

## Verifying this change

Integration and deployments to Nexus were successful.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects delivery guarantees: write, flush, buffering, etc.: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
