### PR TITLE
Fail checkpoints on `AT_LEAST_ONCE` flush errors

### DIFF
--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
@@ -153,7 +153,7 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
     }
 
     @Override
-    public void flush() {
+    public void flush() throws IOException {
 
         /*
          * The ingest channel periodically flushes data based on the buffer configuration, and
@@ -189,13 +189,10 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
                         this.getWriterConfig().getMaxBufferTimeMs());
             }
         } else {
-            // TODO reopen channel:
-            // https://github.com/deltastreaminc/flink-connector-snowflake/issues/11
-            LOGGER.warn(
-                    "Snowflake channel flush did not return a handle to wait on: got {};"
-                            + "Flush will happen within the next buffer time of {}ms",
-                    flushRes.getClass().getSimpleName(),
-                    this.getWriterConfig().getMaxBufferTimeMs());
+            throw new IOException(
+                    String.format(
+                            "Snowflake channel flush did not return a handle to wait on: got %s",
+                            flushRes.getClass().getSimpleName()));
         }
     }
 


### PR DESCRIPTION
Currently, flush is delegated to the ingest buffer, when there are immediate issues with flushing a channel. When this happens, upstream operators will progress, writing more records into the sink where checkpoints are successful.

Follow the same pattern of leniency as the SinkService and immediately fail on issues detected in the `flush()` flow of the `SinkWriter`. This instructs Flink to retry the checkpoint (if configured to do so), and do not progress until the sink has recovered, and successfully flushed all of its buffered data.