### PR TITLE
Use offsets to confirm record delivery

### DIFF
--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkWriter.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkWriter.java
@@ -29,7 +29,6 @@ import io.deltastream.flink.connector.snowflake.sink.context.SnowflakeSinkContex
 import io.deltastream.flink.connector.snowflake.sink.internal.SnowflakeSinkService;
 import io.deltastream.flink.connector.snowflake.sink.internal.SnowflakeSinkServiceImpl;
 import io.deltastream.flink.connector.snowflake.sink.serialization.SnowflakeRowSerializationSchema;
-import net.snowflake.ingest.utils.SFException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,11 +113,7 @@ class SnowflakeSinkWriter<IN> implements SinkWriter<IN> {
          * Send to the service for eventual write
          * This may flush based on SnowflakeSinkService.SnowflakeWriterConfig
          */
-        try {
-            this.sinkService.insert(this.serializationSchema.serialize(element, sinkContext));
-        } catch (SFException e) {
-            throw new IOException("Failed to insert row with Snowflake sink service", e);
-        }
+        this.sinkService.insert(this.serializationSchema.serialize(element, sinkContext));
     }
 
     @Override

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
@@ -27,8 +27,6 @@ import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
-import dev.failsafe.Failsafe;
-import dev.failsafe.Fallback;
 import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeChannelConfig;
 import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeWriterConfig;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
@@ -36,6 +34,7 @@ import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import net.snowflake.ingest.utils.SFException;
+import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +64,8 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
     private final SnowflakeStreamingIngestClient client;
     // A channel name computed from a unique ingestion name and subtask ID
     private final String channelName;
+    // The expected offset to be committed by the Snowpipe channel
+    private long offset;
 
     /**
      * 1-1 mapping between client/channel/flink subtask Channel for communicating with the Snowflake
@@ -126,6 +127,7 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
                 this.getChannelName(),
                 this.getClient().getName());
         this.channel = Preconditions.checkNotNull(this.openChannelFromConfig());
+        this.offset = getLatestCommittedOffsetFromSnowflakeIngestChannel();
 
         // metrics counters
         final SinkWriterMetricGroup sinkMetricGroup =
@@ -136,19 +138,23 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
 
     @Override
     public void insert(Map<String, Object> row) throws IOException {
+        try {
+            this.offset++;
+            InsertValidationResponse response = this.channel.insertRow(row, Long.toString(offset));
+            this.numRecordsSendCounter.inc();
+            LOGGER.debug("Submitted row to Snowflake ingest channel '{}'", this.getChannelName());
 
-        // send row to ingest channel in a fallback
-        InsertValidationResponse response = this.insertRowWithFallback(row);
-        this.numRecordsSendCounter.inc();
-        LOGGER.debug("Submitted row to Snowflake ingest channel '{}'", this.getChannelName());
-
-        // handle possible errors
-        if (response.hasErrors()) {
-            LOGGER.debug(
-                    "Encountered error on row submission to Snowflake ingest channel '{}'",
-                    this.getChannelName());
-            this.numRecordsSendError.inc(response.getErrorRowCount());
-            this.handleInsertRowsErrors(response.getInsertErrors());
+            // handle possible errors
+            if (ObjectUtils.isNotEmpty(response) && response.hasErrors()) {
+                LOGGER.debug(
+                        "Encountered error on row submission to Snowflake ingest channel '{}'",
+                        this.getChannelName());
+                this.numRecordsSendError.inc(response.getErrorRowCount());
+                this.handleInsertRowsErrors(response.getInsertErrors());
+            }
+        } catch (SFException e) {
+            // SFException can be thrown by insertRow()
+            throw new IOException("Failed to insert row with Snowflake sink service", e);
         }
     }
 
@@ -168,6 +174,7 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
         }
 
         LOGGER.debug("Flushing Snowflake ingest channel '{}'", this.getChannelName());
+
         final Object flushRes =
                 invoke(
                         this.getChannel(),
@@ -189,6 +196,17 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
                             "Snowflake channel flush did not return a handle to wait on: got %s",
                             flushRes.getClass().getSimpleName()));
         }
+
+        while (this.getLatestCommittedOffsetFromSnowflakeIngestChannel() < this.offset) {
+            try {
+                LOGGER.info(
+                        "Sleeping 1000ms to allow Snowflake ingest channel committed offsets to catch up");
+                Thread.sleep(1000L);
+            } catch (InterruptedException e) {
+                LOGGER.warn(
+                        "Thread sleep interrupted while waiting for Snowflake records to flush");
+            }
+        }
     }
 
     SnowflakeStreamingIngestClient createClientFromConfig(
@@ -206,7 +224,7 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
      *
      * @return {@link SnowflakeStreamingIngestChannel}
      */
-    private SnowflakeStreamingIngestChannel openChannelFromConfig() {
+    SnowflakeStreamingIngestChannel openChannelFromConfig() {
         OpenChannelRequest channelRequest =
                 OpenChannelRequest.builder(this.getChannelName())
                         .setDBName(this.getChannelConfig().getDatabaseName())
@@ -274,47 +292,24 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
                 errors.get(0).getException());
     }
 
-    /**
-     * Reopen the ingestion channel on {@link SFException} using {@link dev.failsafe.Fallback}.
-     *
-     * @param row {@link java.util.Map} to send to Snowflake for eventual flush
-     * @return {@link InsertValidationResponse}
-     */
-    private InsertValidationResponse insertRowWithFallback(final Map<String, Object> row) {
-        Fallback<Object> reopenChannelFallbackExecutorForInsertRows =
-                Fallback.builder(
-                                attempt -> {
-                                    this.ingestionFallbackSupplier(attempt.getLastException());
-                                })
-                        .handle(SFException.class)
-                        .onFailedAttempt(
-                                event ->
-                                        LOGGER.warn(
-                                                "Failed to send row to ingest channel",
-                                                event.getLastException()))
-                        .onFailure(
-                                event ->
-                                        LOGGER.error(
-                                                String.format(
-                                                        "[INSERT_ROW_FALLBACK] Failed to re-open channel '%s'",
-                                                        this.getChannelName()),
-                                                event.getException()))
-                        .build();
-
-        return Failsafe.with(reopenChannelFallbackExecutorForInsertRows)
-                .get(() -> this.channel.insertRow(row, null));
-    }
-
-    /**
-     * Fail on any errors that may have happened during ingestion to the Snowflake service.
-     *
-     * @param throwable {@link Throwable}
-     */
-    private void ingestionFallbackSupplier(final Throwable throwable) {
-        LOGGER.warn(
-                "[INSERT_ROWS_FALLBACK] Failed to insert row with channel '{}'. Exiting with error",
-                this.getChannelName());
-        throw new RuntimeException(throwable);
+    private long getLatestCommittedOffsetFromSnowflakeIngestChannel() {
+        Map<String, String> offsetTokens =
+                this.getClient().getLatestCommittedOffsetTokens(List.of(this.getChannel()));
+        Preconditions.checkState(
+                offsetTokens.size() == 1,
+                String.format(
+                        "Expected getLatestCommittedOffsetTokens to return information for a single channel. Found %s offset tokens.",
+                        offsetTokens.size()));
+        String offsetToken = offsetTokens.get(offsetTokens.keySet().iterator().next());
+        try {
+            return ObjectUtils.isEmpty(offsetToken) ? 0 : Long.parseLong(offsetToken);
+        } catch (NumberFormatException e) {
+            LOGGER.error(
+                    "The offsetToken string does not contain a parsable long:{} for channel:{}",
+                    offsetToken,
+                    this.getChannelName());
+            throw e;
+        }
     }
 
     /**

--- a/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkITCase.java
+++ b/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkITCase.java
@@ -6,13 +6,12 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Maps;
-
 import io.deltastream.flink.connector.snowflake.sink.context.SnowflakeSinkContext;
 import io.deltastream.flink.connector.snowflake.sink.serialization.SnowflakeRowSerializationSchema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.com.google.common.collect.Maps;
 import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
 import org.testcontainers.shaded.org.apache.commons.lang3.SystemUtils;
 
@@ -83,22 +82,19 @@ class SnowflakeSinkITCase {
         env.execute();
     }
 
-    protected static Map<String, Object> buildRow(final Long id) {
-        final String uuid = UUID.randomUUID().toString();
-        return Map.of(
-                "\"id\"",
-                uuid + "-" + id,
-                "\"data\"",
-                uuid + "_" + id); // case-sensitive column names
-    }
-
     private static class SfRowMapFunction implements MapFunction<Long, Map<String, Object>> {
 
         private static final long serialVersionUID = -2836417330784371895L;
 
         @Override
         public Map<String, Object> map(Long id) {
-            return Maps.newHashMap(buildRow(id));
+            final String uuid = UUID.randomUUID().toString();
+            return Maps.newHashMap(
+                    Map.of(
+                            "\"id\"",
+                            uuid + "-" + id,
+                            "\"data\"",
+                            uuid + "_" + id)); // case-sensitive column names
         }
     }
 

--- a/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImplTest.java
+++ b/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImplTest.java
@@ -1,0 +1,240 @@
+package io.deltastream.flink.connector.snowflake.sink.internal;
+
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+
+import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeChannelConfig;
+import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeWriterConfig;
+import net.snowflake.ingest.streaming.FakeSnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.streaming.FakeSnowflakeStreamingIngestClient;
+import net.snowflake.ingest.streaming.InsertValidationResponse;
+import net.snowflake.ingest.streaming.InsertValidationResponse.InsertError;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.SFException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+class SnowflakeSinkServiceImplTest {
+
+    @Test
+    void testSuccessfulInsert() throws IOException {
+        SnowflakeSinkServiceImpl sinkService =
+                new FakeSnowflakeSinkServiceImpl(
+                        "appId",
+                        0,
+                        new Properties(),
+                        SnowflakeWriterConfig.builder().build(),
+                        SnowflakeChannelConfig.builder()
+                                .build("FAKE_DB", "FAKE_SCHEMA", "FAKE_TABLE"),
+                        new FakeSinkWriterMetricGroup());
+        Assertions.assertEquals(
+                0, sinkService.getLatestCommittedOffsetFromSnowflakeIngestChannel());
+        sinkService.insert(Map.of("field_1", "val_1"));
+        Assertions.assertEquals(
+                1, sinkService.getLatestCommittedOffsetFromSnowflakeIngestChannel());
+    }
+
+    @Test
+    void testInsertExceptionHandling() throws IOException {
+        SnowflakeSinkServiceImpl sinkService =
+                new FakeSnowflakeSinkServiceImpl(
+                        "appId",
+                        0,
+                        new Properties(),
+                        SnowflakeWriterConfig.builder().build(),
+                        SnowflakeChannelConfig.builder()
+                                .build("FAKE_DB", "FAKE_SCHEMA", "FAKE_TABLE"),
+                        new FakeSinkWriterMetricGroup()) {
+                    @Override
+                    public SnowflakeStreamingIngestChannel getChannel() {
+                        return new FakeSnowflakeStreamingIngestChannel(
+                                this.getChannelName(),
+                                this.getChannelConfig().getDatabaseName(),
+                                this.getChannelConfig().getSchemaName(),
+                                this.getChannelConfig().getTableName()) {
+                            @Override
+                            public InsertValidationResponse insertRow(
+                                    Map<String, Object> row, String offsetToken) {
+                                throw new SFException(ErrorCode.INTERNAL_ERROR, "test");
+                            }
+                        };
+                    }
+                };
+        IOException e =
+                Assertions.assertThrows(
+                        IOException.class, () -> sinkService.insert(Map.of("field_1", "val_1")));
+        Assertions.assertTrue(
+                e.getMessage().contains("Failed to insert row with Snowflake sink service"));
+    }
+
+    @Test
+    void testInsertErrornHandling() throws IOException {
+        SnowflakeSinkServiceImpl sinkService =
+                new FakeSnowflakeSinkServiceImpl(
+                        "appId",
+                        0,
+                        new Properties(),
+                        SnowflakeWriterConfig.builder().build(),
+                        SnowflakeChannelConfig.builder()
+                                .build("FAKE_DB", "FAKE_SCHEMA", "FAKE_TABLE"),
+                        new FakeSinkWriterMetricGroup()) {
+                    @Override
+                    public SnowflakeStreamingIngestChannel getChannel() {
+                        return new FakeSnowflakeStreamingIngestChannel(
+                                this.getChannelName(),
+                                this.getChannelConfig().getDatabaseName(),
+                                this.getChannelConfig().getSchemaName(),
+                                this.getChannelConfig().getTableName()) {
+                            @Override
+                            public InsertValidationResponse insertRow(
+                                    Map<String, Object> row, String offsetToken) {
+                                InsertValidationResponse res = new InsertValidationResponse();
+                                InsertError insertError =
+                                        new InsertError(row, Long.parseLong(offsetToken));
+                                insertError.setException(
+                                        new SFException(ErrorCode.INTERNAL_ERROR, "test"));
+                                res.addError(insertError);
+                                return res;
+                            }
+                        };
+                    }
+                };
+        IOException e =
+                Assertions.assertThrows(
+                        IOException.class, () -> sinkService.insert(Map.of("field_1", "val_1")));
+        Assertions.assertTrue(
+                e.getMessage()
+                        .contains(
+                                "Encountered errors while ingesting rows into Snowflake: Ingest client internal error: test."));
+    }
+
+    private class FakeSnowflakeSinkServiceImpl extends SnowflakeSinkServiceImpl {
+
+        /**
+         * Construct a new sink service to provide APIs to the Snowflake service.
+         *
+         * @param appId {@link String} UID for Flink job
+         * @param taskId {@link Integer} Flink subtask ID
+         * @param connectionConfig {@link Properties} Snowflake connection settings
+         * @param writerConfig {@link SnowflakeWriterConfig}
+         * @param channelConfig {@link SnowflakeChannelConfig}
+         * @param metricGroup {@link SinkWriterMetricGroup}
+         */
+        public FakeSnowflakeSinkServiceImpl(
+                String appId,
+                int taskId,
+                Properties connectionConfig,
+                SnowflakeWriterConfig writerConfig,
+                SnowflakeChannelConfig channelConfig,
+                SinkWriterMetricGroup metricGroup) {
+            super(appId, taskId, connectionConfig, writerConfig, channelConfig, metricGroup);
+        }
+
+        @Override
+        SnowflakeStreamingIngestClient createClientFromConfig(
+                final String appId, final Properties connectionConfig) {
+            return new FakeSnowflakeStreamingIngestClient(this.getChannelName());
+        }
+    }
+
+    private class FakeSinkWriterMetricGroup implements SinkWriterMetricGroup {
+
+        @Override
+        public Counter getNumRecordsOutErrorsCounter() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Counter getNumRecordsSendErrorsCounter() {
+            return new SimpleCounter();
+        }
+
+        @Override
+        public Counter getNumRecordsSendCounter() {
+            return new SimpleCounter();
+        }
+
+        @Override
+        public Counter getNumBytesSendCounter() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setCurrentSendTimeGauge(Gauge<Long> currentSendTimeGauge) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public OperatorIOMetricGroup getIOMetricGroup() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Counter counter(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <C extends Counter> C counter(String name, C counter) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <H extends Histogram> H histogram(String name, H histogram) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <M extends Meter> M meter(String name, M meter) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MetricGroup addGroup(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MetricGroup addGroup(String key, String value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String[] getScopeComponents() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getAllVariables() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getMetricIdentifier(String metricName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getMetricIdentifier(String metricName, CharacterFilter filter) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestChannel.java
+++ b/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestChannel.java
@@ -1,0 +1,113 @@
+package net.snowflake.ingest.streaming;
+
+import net.snowflake.ingest.streaming.internal.ColumnProperties;
+import org.testcontainers.shaded.com.google.common.collect.Lists;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Fake implementation of {@link SnowflakeStreamingIngestChannel} which stores state in memory. This
+ * implementation is used for testing and is able to keep state between calls: so inserting rows
+ * through {@link SnowflakeStreamingIngestChannel#insertRow} will update the {@link
+ * SnowflakeStreamingIngestChannel#getLatestCommittedOffsetToken()}.
+ *
+ * <p>Note that this implementation is not thread safe and some functionality may be missing.
+ */
+public class FakeSnowflakeStreamingIngestChannel implements SnowflakeStreamingIngestChannel {
+    private final String name;
+    private final String fullyQualifiedName;
+    private final String dbName;
+    private final String schemaName;
+    private final String tableName;
+    private final String fullyQualifiedTableName;
+    private boolean closed;
+    private String offsetToken;
+
+    private List<Map<String, Object>> rows = new LinkedList<>();
+
+    public FakeSnowflakeStreamingIngestChannel(
+            String name, String dbName, String schemaName, String tableName) {
+        this.name = name;
+        this.dbName = dbName;
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.fullyQualifiedName = String.format("%s.%s.%s.%s", dbName, schemaName, tableName, name);
+        this.fullyQualifiedTableName = String.format("%s.%s.%s", dbName, schemaName, tableName);
+    }
+
+    @Override
+    public String getFullyQualifiedName() {
+        return fullyQualifiedName;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getDBName() {
+        return dbName;
+    }
+
+    @Override
+    public String getSchemaName() {
+        return schemaName;
+    }
+
+    @Override
+    public String getTableName() {
+        return tableName;
+    }
+
+    @Override
+    public String getFullyQualifiedTableName() {
+        return fullyQualifiedTableName;
+    }
+
+    @Override
+    public boolean isValid() {
+        return true;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+        closed = true;
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public InsertValidationResponse insertRow(Map<String, Object> row, String offsetToken) {
+        return this.insertRows(Lists.newArrayList(row), offsetToken);
+    }
+
+    @Override
+    public InsertValidationResponse insertRows(
+            Iterable<Map<String, Object>> rows, String offsetToken) {
+        final List<Map<String, Object>> rowsCopy = new LinkedList<>();
+        rows.forEach(r -> rowsCopy.add(new LinkedHashMap<>(r)));
+        this.rows.addAll(rowsCopy);
+        this.offsetToken = offsetToken;
+        return new InsertValidationResponse();
+    }
+
+    @Override
+    public String getLatestCommittedOffsetToken() {
+        return offsetToken;
+    }
+
+    @Override
+    public Map<String, ColumnProperties> getTableSchema() {
+        throw new UnsupportedOperationException(
+                "Method is unsupported in fake communication channel");
+    }
+}

--- a/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestClient.java
+++ b/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestClient.java
@@ -58,10 +58,7 @@ public class FakeSnowflakeStreamingIngestClient implements SnowflakeStreamingIng
         channels.forEach(
                 c -> {
                     String fqn = c.getFullyQualifiedName();
-                    String token =
-                            channelCache
-                                    .get(c.getFullyQualifiedName())
-                                    .getLatestCommittedOffsetToken();
+                    String token = channelCache.get(fqn).getLatestCommittedOffsetToken();
                     offsetTokens.put(fqn, token);
                 });
         return offsetTokens;

--- a/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestClient.java
+++ b/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestClient.java
@@ -1,0 +1,74 @@
+package net.snowflake.ingest.streaming;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Fake implementation of {@link SnowflakeStreamingIngestClient} which stores state in memory. This
+ * implementation is used for testing and works together with {@link
+ * FakeSnowflakeStreamingIngestChannel} for simulating ingest-sdk.
+ *
+ * <p>Note that this implementation is not thread safe and some functionality may be missing.
+ */
+public class FakeSnowflakeStreamingIngestClient implements SnowflakeStreamingIngestClient {
+
+    private final String name;
+    private boolean closed;
+    private final ConcurrentHashMap<String, FakeSnowflakeStreamingIngestChannel> channelCache =
+            new ConcurrentHashMap<>();
+
+    public FakeSnowflakeStreamingIngestClient(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public SnowflakeStreamingIngestChannel openChannel(OpenChannelRequest request) {
+        String fqdn =
+                String.format(
+                        "%s.%s", request.getFullyQualifiedTableName(), request.getChannelName());
+        return channelCache.computeIfAbsent(
+                fqdn,
+                (key) ->
+                        new FakeSnowflakeStreamingIngestChannel(
+                                name,
+                                request.getDBName(),
+                                request.getSchemaName(),
+                                request.getTableName()));
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setRefreshToken(String refreshToken) {}
+
+    @Override
+    public boolean isClosed() {
+        return closed;
+    }
+
+    @Override
+    public Map<String, String> getLatestCommittedOffsetTokens(
+            List<SnowflakeStreamingIngestChannel> channels) {
+        Map<String, String> offsetTokens = new HashMap<>();
+        channels.forEach(
+                c -> {
+                    String fqn = c.getFullyQualifiedName();
+                    String token =
+                            channelCache
+                                    .get(c.getFullyQualifiedName())
+                                    .getLatestCommittedOffsetToken();
+                    offsetTokens.put(fqn, token);
+                });
+        return offsetTokens;
+    }
+
+    @Override
+    public void close() throws Exception {
+        closed = true;
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/deltastreaminc/flink-connector-snowflake/issues/18
Relates to https://github.com/deltastreaminc/flink-connector-snowflake/issues/24

## What is the purpose of the change

Improves on our at-least-once guarantees by waiting for the SnowflakeStreamingIngestChannel to return the proper offsets before completing Flink checkpoint.

Currently, we rely on a `flush()` call to the snowflake ingest channel to guarantee at least once. With this change, we will do an extra validation that the offsets returned by the channel match the number of records we have flushed.

## Brief change log

- Count number of records (offset) we are flushing to Snowflake channel and ensure that the offsets returned by the channel  after `flush()` match our expectations before completing a Flink checkpoint
- Simplifies some error handling when inserting records
- Add `FakeSnowflakeStreamingIngestClient` and `FakeSnowflakeStreamingIngestChannel` classes to assist with unit testing
- Add unit tests for `SnowflakeSinkServiceImpl`

## Verifying this change

Unit tests pass and simple integration test for Snowflake connector passes.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): Adds some overhead during checkpointing
- Anything that affects delivery guarantees: write, flush, buffering, etc.: Should improve at-least-once delivery guarantee

## Documentation

- Does this pull request introduce a new feature? no
