### PR TITLE
Add same private key passphrase options as OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following credentials are used in the tests for integrating with the Snowfla
 * `SNOWFLAKE_USER`: Username to write data as
 * `SNOWFLAKE_ROLE`: Database role to write data as
 * `SNOWFLAKE_PRIVATE_KEY`: User's private key to use for connecting to the service
-* `SNOWFLAKE_KEY_PASSPHRASE`: User's private key password to use for connecting to the service
+* `SNOWFLAKE_KEY_PASSPHRASE`: User's private key password to use for connecting to the service, as supported by OpenSSL guidelines
 
 ### Integration Test
 

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkBuilder.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkBuilder.java
@@ -132,7 +132,7 @@ public class SnowflakeSinkBuilder<IN> {
      */
     public SnowflakeSinkBuilder<IN> keyPassphrase(final String connectionKeyPassphrase) {
         Preconditions.checkArgument(
-                !StringUtils.isNullOrWhitespaceOnly(connectionKeyPassphrase),
+                connectionKeyPassphrase != null,
                 String.format("Invalid %s", SNOWFLAKE_KEY_PASSPHRASE_CONFIG_NAME));
         this.connectionProps.put(SNOWFLAKE_KEY_PASSPHRASE_CONFIG_NAME, connectionKeyPassphrase);
         return this;

--- a/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkBuilderTest.java
+++ b/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkBuilderTest.java
@@ -93,4 +93,27 @@ class SnowflakeSinkBuilderTest {
                                 SnowflakeSinkBuilder.SNOWFLAKE_KEY_PASSPHRASE_CONFIG_NAME,
                                 SnowflakeSinkBuilder.SNOWFLAKE_PRIVATE_KEY_CONFIG_NAME));
     }
+
+    @Test
+    public void testFailureOnMissingPrivateKeyWithEmptyPassphrase() {
+        final SnowflakeSinkBuilder<Map<String, Object>> bSink =
+                SnowflakeSink.<Map<String, Object>>builder()
+                        .url("test-url")
+                        .user("test-user")
+                        .role("test-role")
+                        .database("test_db")
+                        .schema("test_schema")
+                        .table("test_table")
+                        .privateKey("some-priv-key")
+                        .keyPassphrase("")
+                        .serializationSchema(
+                                ((SnowflakeRowSerializationSchema<Map<String, Object>>)
+                                        (element, sinkContext) -> element));
+
+        final SnowflakeSink<Map<String, Object>> sink = bSink.build("passphrase-test");
+        Assertions.assertThat(
+                        sink.getConnectionConfigs()
+                                .get(SnowflakeSinkBuilder.SNOWFLAKE_KEY_PASSPHRASE_CONFIG_NAME))
+                .isEqualTo("");
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

OpenSSL supports encrypted private keys with an empty-string passphrase, so does the connector with this change.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects delivery guarantees: write, flush, buffering, etc.: no

## Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? `README.md`
