### PR TITLE
Add JDK 11 to the releases

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         java:
+          - 11
           - 17
     permissions:
       contents: read
@@ -36,12 +37,19 @@ jobs:
       run:
         cat <(echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}") | gpg --batch --import
 
+    - name: Create version name
+      run: |
+        if [ "${{ matrix.java }}" != "17" ]; then
+          echo "VERSION_NAME=${{ github.event.release.tag_name }}-j${{ matrix.java }}" >> $GITHUB_ENV
+        else
+          echo "VERSION_NAME=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+
     - name: Build and Release Artifact
       id: release-jar
       run: |
         cd flink-connector-snowflake && \
           mvn deploy -P docs-and-source,release \
-            -Drevision=${{ github.event.release.tag_name }} \
+            -Drevision=${{ env.VERSION_NAME }} \
             -U -B -ff -fae \
             -s $GITHUB_WORKSPACE/settings.xml \
             -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         java:
+          - 11
           - 17
     permissions:
       contents: read
@@ -32,10 +33,17 @@ jobs:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
 
+    - name: Create version name
+      run: |
+        if [ "${{ matrix.java-version }}" != "17" ]; then
+          echo "VERSION_NAME=${{ github.event.pull_request.head.sha }}-${{ matrix.java-version }}" >> $GITHUB_ENV
+        else
+          echo "VERSION_NAME=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+
     - name: Test and Build Artifact
       id: build
       run: |
         mvn package \
-          -Drevision=${{ github.event.pull_request.head.sha }} \
+          -Drevision=${{ env.VERSION_NAME }} \
           -U -B -ff -fae \
           -f pom.xml

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -35,8 +35,8 @@ jobs:
 
     - name: Create version name
       run: |
-        if [ "${{ matrix.java-version }}" != "17" ]; then
-          echo "VERSION_NAME=${{ github.event.pull_request.head.sha }}-${{ matrix.java-version }}" >> $GITHUB_ENV
+        if [ "${{ matrix.java }}" != "17" ]; then
+          echo "VERSION_NAME=${{ github.event.pull_request.head.sha }}-${{ matrix.java }}" >> $GITHUB_ENV
         else
           echo "VERSION_NAME=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Create version name
       run: |
         if [ "${{ matrix.java }}" != "17" ]; then
-          echo "VERSION_NAME=${{ github.event.pull_request.head.sha }}-${{ matrix.java }}" >> $GITHUB_ENV
+          echo "VERSION_NAME=${{ github.event.pull_request.head.sha }}-j${{ matrix.java }}" >> $GITHUB_ENV
         else
           echo "VERSION_NAME=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 


### PR DESCRIPTION
Fixes https://github.com/deltastreaminc/flink-connector-snowflake/issues/31

## What is the purpose of the change

Adding Java 11 to the list of supported JDKs in the pull request and main release workflows to allow running the connector on environments with a different JDK support.

## Verifying this change

This is going to be tested in the follow up PRs, but will be a candidate release that will be tested in e2e.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects delivery guarantees: write, flush, buffering, etc.: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
