### PR TITLE
Upgrade to Flink 1.19 + tooling cleanup

### DIFF
--- a/flink-connector-snowflake/pom.xml
+++ b/flink-connector-snowflake/pom.xml
@@ -109,11 +109,6 @@
         </dependency>
 
         <dependency>
-            <groupId>dev.failsafe</groupId>
-            <artifactId>failsafe</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
@@ -184,10 +179,6 @@
                                 </filter>
                             </filters>
                             <relocations>
-                                <relocation>
-                                    <pattern>dev.failsafe</pattern>
-                                    <shadedPattern>org.apache.flink.shaded.dev.failsafe</shadedPattern>
-                                </relocation>
                                 <relocation>
                                     <pattern>net.snowflake</pattern>
                                     <shadedPattern>org.apache.flink.shaded.net.snowflake</shadedPattern>

--- a/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkITCase.java
+++ b/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkITCase.java
@@ -6,15 +6,17 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 
+import org.apache.flink.shaded.guava31.com.google.common.collect.Maps;
+
 import io.deltastream.flink.connector.snowflake.sink.context.SnowflakeSinkContext;
 import io.deltastream.flink.connector.snowflake.sink.serialization.SnowflakeRowSerializationSchema;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.shaded.com.google.common.collect.Maps;
-import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
-import org.testcontainers.shaded.org.apache.commons.lang3.SystemUtils;
 
+import java.io.Serial;
 import java.util.Map;
 import java.util.UUID;
 
@@ -84,7 +86,7 @@ class SnowflakeSinkITCase {
 
     private static class SfRowMapFunction implements MapFunction<Long, Map<String, Object>> {
 
-        private static final long serialVersionUID = -2836417330784371895L;
+        @Serial private static final long serialVersionUID = -2836417330784371895L;
 
         @Override
         public Map<String, Object> map(Long id) {
@@ -101,7 +103,7 @@ class SnowflakeSinkITCase {
     private static class RowPassThroughSerializer
             implements SnowflakeRowSerializationSchema<Map<String, Object>> {
 
-        private static final long serialVersionUID = -23875899103249615L;
+        @Serial private static final long serialVersionUID = -23875899103249615L;
 
         @Override
         public Map<String, Object> serialize(

--- a/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkITCase.java
+++ b/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkITCase.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.io.Serial;
 import java.util.Map;
 import java.util.UUID;
 
@@ -86,7 +85,7 @@ class SnowflakeSinkITCase {
 
     private static class SfRowMapFunction implements MapFunction<Long, Map<String, Object>> {
 
-        @Serial private static final long serialVersionUID = -2836417330784371895L;
+        private static final long serialVersionUID = -2836417330784371895L;
 
         @Override
         public Map<String, Object> map(Long id) {
@@ -103,7 +102,7 @@ class SnowflakeSinkITCase {
     private static class RowPassThroughSerializer
             implements SnowflakeRowSerializationSchema<Map<String, Object>> {
 
-        @Serial private static final long serialVersionUID = -23875899103249615L;
+        private static final long serialVersionUID = -23875899103249615L;
 
         @Override
         public Map<String, Object> serialize(

--- a/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestChannel.java
+++ b/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestChannel.java
@@ -1,7 +1,8 @@
 package net.snowflake.ingest.streaming;
 
+import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
+
 import net.snowflake.ingest.streaming.internal.ColumnProperties;
-import org.testcontainers.shaded.com.google.common.collect.Lists;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedList;

--- a/flink-connector-snowflake/src/test/resources/log4j2-test.properties
+++ b/flink-connector-snowflake/src/test/resources/log4j2-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
 		<objenesis.version>2.1</objenesis.version>
 
 		<snowflake-ingest.version>2.0.4</snowflake-ingest.version>
-		<failsafe.version>3.3.2</failsafe.version>
 		<assertj.version>3.21.0</assertj.version>
 		<junit5.version>5.10.0</junit5.version>
 		<testcontainers.version>1.19.1</testcontainers.version>
@@ -174,12 +173,6 @@
 				<groupId>net.snowflake</groupId>
 				<artifactId>snowflake-ingest-sdk</artifactId>
 				<version>${snowflake-ingest.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>dev.failsafe</groupId>
-				<artifactId>failsafe</artifactId>
-				<version>${failsafe.version}</version>
 			</dependency>
 
 			<!-- Flink dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<target.java.version>${java.version}</target.java.version>
 
-		<flink.version>1.18.0</flink.version>
+		<flink.version>1.19.1</flink.version>
 		<kryo.version>2.24.0</kryo.version>
 		<objenesis.version>2.1</objenesis.version>
 


### PR DESCRIPTION
- Moved to Flink 1.19.1
- Removed deprecated `dev.failsafe` tooling
- Moved to Flink utils Guava31 usage from Testcontainers.

## Verifying this change

Succssfully wrote to external service with IT.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects delivery guarantees: write, flush, buffering, etc.: no

## Documentation

- Does this pull request introduce a new feature? no
