### PR TITLE
Bump net.snowflake:snowflake-ingest-sdk to 2.3.0

### DIFF
--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeStreamingIngestClientProvider.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeStreamingIngestClientProvider.java
@@ -87,7 +87,7 @@ public class SnowflakeStreamingIngestClientProvider {
         Preconditions.checkNotNull(writerConfig, "writerConfig");
         return Maps.newHashMap(
                 Map.of(
-                        ParameterProvider.BUFFER_FLUSH_INTERVAL_IN_MILLIS, // buffer time
+                        ParameterProvider.MAX_CLIENT_LAG, // buffer time
                         writerConfig.getMaxBufferTimeMs(),
                         ParameterProvider
                                 .ENABLE_SNOWPIPE_STREAMING_METRICS, // snowpipe streaming metrics

--- a/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestChannel.java
+++ b/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestChannel.java
@@ -82,6 +82,11 @@ public class FakeSnowflakeStreamingIngestChannel implements SnowflakeStreamingIn
 
     @Override
     public CompletableFuture<Void> close() {
+        return this.close(false);
+    }
+
+    @Override
+    public CompletableFuture<Void> close(boolean b) {
         closed = true;
         return CompletableFuture.completedFuture(null);
     }
@@ -93,12 +98,20 @@ public class FakeSnowflakeStreamingIngestChannel implements SnowflakeStreamingIn
 
     @Override
     public InsertValidationResponse insertRows(
-            Iterable<Map<String, Object>> rows, String offsetToken) {
+            Iterable<Map<String, Object>> iterable,
+            String startOffsetToken,
+            String endOffsetToken) {
         final List<Map<String, Object>> rowsCopy = new LinkedList<>();
         rows.forEach(r -> rowsCopy.add(new LinkedHashMap<>(r)));
         this.rows.addAll(rowsCopy);
-        this.offsetToken = offsetToken;
+        this.offsetToken = endOffsetToken;
         return new InsertValidationResponse();
+    }
+
+    @Override
+    public InsertValidationResponse insertRows(
+            Iterable<Map<String, Object>> rows, String offsetToken) {
+        return this.insertRows(rows, null, offsetToken);
     }
 
     @Override

--- a/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestClient.java
+++ b/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestClient.java
@@ -39,6 +39,15 @@ public class FakeSnowflakeStreamingIngestClient implements SnowflakeStreamingIng
     }
 
     @Override
+    public void dropChannel(DropChannelRequest dropChannelRequest) {
+        channelCache.remove(
+                String.format(
+                        "%s.%s",
+                        dropChannelRequest.getFullyQualifiedTableName(),
+                        dropChannelRequest.getChannelName()));
+    }
+
+    @Override
     public String getName() {
         return name;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<kryo.version>2.24.0</kryo.version>
 		<objenesis.version>2.1</objenesis.version>
 
-		<snowflake-ingest.version>2.0.4</snowflake-ingest.version>
+		<snowflake-ingest.version>2.3.0</snowflake-ingest.version>
 		<assertj.version>3.21.0</assertj.version>
 		<junit5.version>5.10.0</junit5.version>
 		<testcontainers.version>1.19.1</testcontainers.version>


### PR DESCRIPTION
Fixes https://github.com/deltastreaminc/flink-connector-snowflake/issues/30
Fixes https://github.com/deltastreaminc/flink-connector-snowflake/issues/35

- Bump `net.snowflake:snowflake-ingest-sdk` dependency to version 2.3.0
- Move to `MAX_CLIENT_LAG` channel property from `BUFFER_FLUSH_INTERVAL_IN_MILLIS`.

## Verifying this change

Successfully writes to external Snowflake account using the IT.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects delivery guarantees: write, flush, buffering, etc.: no

## Documentation

- Does this pull request introduce a new feature? no
