### PR TITLE
Add `WriterInitcontext` on Flink 1.20

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,7 +44,7 @@ This change added tests and can be verified as describe. Please describe the int
 
 In all cases, ensure that at least a simple integration test with a Snowflake account successfully runs.
 
-## Does this pull request potentially affect one of the following parts:
+## Does this pull request potentially affect one of the following parts
 
 - Dependencies (does it add or upgrade a dependency): (yes / no)
 - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSink.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSink.java
@@ -20,6 +20,7 @@ package io.deltastream.flink.connector.snowflake.sink;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
@@ -102,8 +103,12 @@ public class SnowflakeSink<IN> implements Sink<IN> {
         return new SnowflakeSinkBuilder<>();
     }
 
-    @Override
     public SinkWriter<IN> createWriter(InitContext initContext) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public SinkWriter<IN> createWriter(WriterInitContext initContext) {
         return new SnowflakeSinkWriter<>(
                 new DefaultSnowflakeSinkContext(
                         Preconditions.checkNotNull(initContext, "initContext"),

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/context/DefaultSnowflakeSinkContext.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/context/DefaultSnowflakeSinkContext.java
@@ -18,7 +18,7 @@
 package io.deltastream.flink.connector.snowflake.sink.context;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.connector.base.DeliveryGuarantee;
 
 import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeWriterConfig;
@@ -30,13 +30,13 @@ import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeWriterConfi
 @Internal
 public class DefaultSnowflakeSinkContext implements SnowflakeSinkContext {
 
-    private final Sink.InitContext initContext;
+    private final WriterInitContext initContext;
     private final boolean flushOnCheckpoint;
     private final SnowflakeWriterConfig writerConfig;
     private final String appId;
 
     public DefaultSnowflakeSinkContext(
-            Sink.InitContext initContext, SnowflakeWriterConfig writerConfig, String appId) {
+            WriterInitContext initContext, SnowflakeWriterConfig writerConfig, String appId) {
         this.initContext = initContext;
         this.writerConfig = writerConfig;
         this.flushOnCheckpoint =
@@ -45,7 +45,7 @@ public class DefaultSnowflakeSinkContext implements SnowflakeSinkContext {
     }
 
     @Override
-    public Sink.InitContext getInitContext() {
+    public WriterInitContext getInitContext() {
         return this.initContext;
     }
 

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/context/SnowflakeSinkContext.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/context/SnowflakeSinkContext.java
@@ -18,7 +18,7 @@
 package io.deltastream.flink.connector.snowflake.sink.context;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 
 import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeWriterConfig;
 
@@ -30,7 +30,7 @@ import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeWriterConfi
 public interface SnowflakeSinkContext {
 
     /** Get the current init context in sink. */
-    Sink.InitContext getInitContext();
+    WriterInitContext getInitContext();
 
     /** Get the current process time in Flink. */
     long processTime();

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<target.java.version>${java.version}</target.java.version>
 
-		<flink.version>1.19.1</flink.version>
+		<flink.version>1.20.0</flink.version>
 		<kryo.version>2.24.0</kryo.version>
 		<objenesis.version>2.1</objenesis.version>
 


### PR DESCRIPTION
Fixes #32 
Fixes #42 

## What is the purpose of the change

Replace deprecated `Initcontext` with the newer `WriterInitContext` supported in Flink 1.20.

## Verifying this change

Successfully initiates the `SnowflakeWriter` and writes to the external Snowflake table.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects delivery guarantees: write, flush, buffering, etc.: no

## Documentation

- Does this pull request introduce a new feature? no
