### PR TITLE
Upgrade to Flink 2.0 dependencies and APIs

### DIFF
--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSink.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSink.java
@@ -103,10 +103,6 @@ public class SnowflakeSink<IN> implements Sink<IN> {
         return new SnowflakeSinkBuilder<>();
     }
 
-    public SinkWriter<IN> createWriter(InitContext initContext) {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
     @Override
     public SinkWriter<IN> createWriter(WriterInitContext initContext) {
         return new SnowflakeSinkWriter<>(

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkWriter.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkWriter.java
@@ -85,7 +85,7 @@ class SnowflakeSinkWriter<IN> implements SinkWriter<IN> {
             this.sinkService =
                     new SnowflakeSinkServiceImpl(
                             this.sinkContext.getAppId(),
-                            this.sinkContext.getInitContext().getSubtaskId(),
+                            this.sinkContext.getInitContext().getTaskInfo().getIndexOfThisSubtask(),
                             connectionConfigs,
                             this.sinkContext.getWriterConfig(),
                             channelConfig,
@@ -107,7 +107,7 @@ class SnowflakeSinkWriter<IN> implements SinkWriter<IN> {
     }
 
     @Override
-    public void write(IN element, Context context) throws IOException, InterruptedException {
+    public void write(IN element, Context context) throws IOException {
 
         /*
          * Send to the service for eventual write

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeInternalUtils.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeInternalUtils.java
@@ -17,8 +17,8 @@
 
 package io.deltastream.flink.connector.snowflake.sink.internal;
 
-import org.apache.flink.shaded.guava31.com.google.common.base.Joiner;
-import org.apache.flink.shaded.guava31.com.google.common.base.Preconditions;
+import org.apache.flink.shaded.guava32.com.google.common.base.Joiner;
+import org.apache.flink.shaded.guava32.com.google.common.base.Preconditions;
 
 import org.apache.commons.lang3.StringUtils;
 

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
@@ -25,7 +25,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
+import org.apache.flink.shaded.guava32.com.google.common.collect.Lists;
 
 import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeChannelConfig;
 import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeWriterConfig;

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeStreamingIngestClientProvider.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeStreamingIngestClientProvider.java
@@ -20,7 +20,7 @@ package io.deltastream.flink.connector.snowflake.sink.internal;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Maps;
+import org.apache.flink.shaded.guava32.com.google.common.collect.Maps;
 
 import io.deltastream.flink.connector.snowflake.sink.config.SnowflakeWriterConfig;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;

--- a/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestChannel.java
+++ b/flink-connector-snowflake/src/test/java/net/snowflake/ingest/streaming/FakeSnowflakeStreamingIngestChannel.java
@@ -1,6 +1,6 @@
 package net.snowflake.ingest.streaming;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
+import org.apache.flink.shaded.guava32.com.google.common.collect.Lists;
 
 import net.snowflake.ingest.streaming.internal.ColumnProperties;
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,9 @@
 		<objenesis.version>3.3</objenesis.version>
 
 		<snowflake-ingest.version>2.3.0</snowflake-ingest.version>
-		<assertj.version>3.21.0</assertj.version>
-		<junit5.version>5.10.0</junit5.version>
-		<testcontainers.version>1.19.1</testcontainers.version>
-		<mockito.version>5.2.0</mockito.version>
+		<junit5.version>5.12.2</junit5.version>
+		<testcontainers.version>1.21.0</testcontainers.version>
+		<mockito.version>5.17.0</mockito.version>
 		<jackson-bom.version>2.15.3</jackson-bom.version>
 		<guava.version>32.1.3-jre-19.0</guava.version>
 
@@ -116,19 +115,6 @@
 		</dependency>
 
 		<!-- Test dependencies -->
-
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-inline</artifactId>
-			<type>jar</type>
-			<scope>test</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.mockito</groupId>
@@ -246,24 +232,9 @@
 
 			<dependency>
 				<groupId>org.mockito</groupId>
-				<artifactId>mockito-inline</artifactId>
-				<version>${mockito.version}</version>
-				<type>jar</type>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
 				<version>${mockito.version}</version>
 				<type>jar</type>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.assertj</groupId>
-				<artifactId>assertj-core</artifactId>
-				<version>${assertj.version}</version>
 				<scope>test</scope>
 			</dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,9 @@
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<target.java.version>${java.version}</target.java.version>
 
-		<flink.version>1.20.0</flink.version>
-		<kryo.version>2.24.0</kryo.version>
-		<objenesis.version>2.1</objenesis.version>
+		<flink.version>2.0.0</flink.version>
+		<kryo.version>5.6.2</kryo.version>
+		<objenesis.version>3.3</objenesis.version>
 
 		<snowflake-ingest.version>2.3.0</snowflake-ingest.version>
 		<assertj.version>3.21.0</assertj.version>
@@ -70,6 +70,7 @@
 		<testcontainers.version>1.19.1</testcontainers.version>
 		<mockito.version>5.2.0</mockito.version>
 		<jackson-bom.version>2.15.3</jackson-bom.version>
+		<guava.version>32.1.3-jre-19.0</guava.version>
 
 		<japicmp.skip>false</japicmp.skip>
 		<japicmp.referenceVersion>3.0.0-1.16</japicmp.referenceVersion>
@@ -108,12 +109,13 @@
 			<scope>provided</scope>
 		</dependency>
 
-		<!-- Test dependencies -->
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<scope>test</scope>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-guava</artifactId>
+			<version>${guava.version}</version>
 		</dependency>
+
+		<!-- Test dependencies -->
 
 		<dependency>
 			<groupId>org.assertj</groupId>
@@ -267,7 +269,7 @@
 
 			<!-- For dependency convergence -->
 			<dependency>
-				<groupId>com.esotericsoftware.kryo</groupId>
+				<groupId>com.esotericsoftware</groupId>
 				<artifactId>kryo</artifactId>
 				<version>${kryo.version}</version>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,13 @@
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<target.java.version>${java.version}</target.java.version>
 
+		<!-- Flink dependencies -->
 		<flink.version>2.0.0</flink.version>
 		<kryo.version>5.6.2</kryo.version>
 		<objenesis.version>3.3</objenesis.version>
+		<slf4j.version>1.7.36</slf4j.version>
+		<log4j.version>2.24.1</log4j.version>
+		<jsr305.version>1.3.9</jsr305.version>
 
 		<snowflake-ingest.version>2.3.0</snowflake-ingest.version>
 		<junit5.version>5.12.2</junit5.version>
@@ -75,10 +79,6 @@
 		<japicmp.referenceVersion>3.0.0-1.16</japicmp.referenceVersion>
 		<checkstyle.version>10.18.2</checkstyle.version>
 		<spotless.skip>false</spotless.skip>
-
-		<slf4j.version>1.7.36</slf4j.version>
-		<log4j.version>2.17.2</log4j.version>
-		<jsr305.version>1.3.9</jsr305.version>
 
 		<checksum-maven-plugin.version>1.11</checksum-maven-plugin.version>
 		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>


### PR DESCRIPTION
This is a breaking change driven by the Flink 2.0 release, but also introduces other changes important to the community:

- Moved to Flink's provided shaded Guava to stay inline with the Flink ecosystem expectations
- No more sub-releases for different JDK versions, and each release is compatible with 11, 17, and 21 and the tagged Flink version
- Patches to the 1.x releases will be done as needed, but no more new features will be added to that branch
