### PR TITLE
Delegate channel name prefix to `OpenChannelRequest` at creation

### DIFF
--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeInternalUtils.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeInternalUtils.java
@@ -36,7 +36,7 @@ public class SnowflakeInternalUtils {
      * @return {@link java.lang.String} concatenated non-empty and non-null parts, separated by "_"
      */
     public static String createClientOrChannelName(
-            @Nullable final String prefix, final String name, @Nullable final Integer id) {
+            final String prefix, final String name, @Nullable final Integer id) {
         Preconditions.checkState(
                 StringUtils.isNotBlank(prefix) || StringUtils.isNotBlank(name),
                 "One of prefix or name must be set for ingest client/channel name");
@@ -46,5 +46,18 @@ public class SnowflakeInternalUtils {
                         StringUtils.isBlank(prefix) ? null : prefix,
                         StringUtils.isEmpty(name) ? null : name,
                         id);
+    }
+
+    /**
+     * Generate a name for ingest client or channel from given parts, skipping null or empty parts.
+     *
+     * @param name {@link java.lang.String} a name
+     * @param id {@link java.lang.Integer} an identifier number
+     * @return {@link java.lang.String} concatenated non-empty and non-null parts, separated by "_"
+     */
+    public static String createClientOrChannelName(final String name, @Nullable final Integer id) {
+        Preconditions.checkState(
+                StringUtils.isNotBlank(name), "name must be set for ingest client/channel name");
+        return Joiner.on("_").skipNulls().join(StringUtils.isEmpty(name) ? null : name, id);
     }
 }

--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImpl.java
@@ -121,15 +121,7 @@ public class SnowflakeSinkServiceImpl implements SnowflakeSinkService {
             SinkWriterMetricGroup metricGroup) {
         this.writerConfig = Preconditions.checkNotNull(writerConfig, "writerConfig");
         this.channelConfig = Preconditions.checkNotNull(channelConfig, "channelConfig");
-        this.channelName =
-                SnowflakeInternalUtils.createClientOrChannelName(
-                        String.format(
-                                "%s_%s_%s",
-                                channelConfig.getDatabaseName(),
-                                channelConfig.getSchemaName(),
-                                channelConfig.getTableName()),
-                        appId,
-                        taskId);
+        this.channelName = SnowflakeInternalUtils.createClientOrChannelName(appId, taskId);
 
         // ingest client
         this.client = this.createClientFromConfig(appId, connectionConfig);

--- a/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImplTest.java
+++ b/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImplTest.java
@@ -175,7 +175,7 @@ class SnowflakeSinkServiceImplTest {
     }
 
     @Test
-    void testChannelNameIncludesTableInformation() {
+    void testChannelNameIncludesTableInformation() throws Exception {
         // Test that channel name includes database, schema, and table name in the prefix
         try (SnowflakeSinkServiceImpl sinkService =
                 new FakeSnowflakeSinkServiceImpl(
@@ -189,63 +189,16 @@ class SnowflakeSinkServiceImplTest {
             String channelName = sinkService.getChannelName();
 
             // Verify that the channel name contains the database, schema, and table information
-            Assertions.assertTrue(
-                    channelName.contains("TEST_DB"), "Channel name should contain database name");
-            Assertions.assertTrue(
-                    channelName.contains("TEST_SCHEMA"), "Channel name should contain schema name");
-            Assertions.assertTrue(
-                    channelName.contains("TEST_TABLE"), "Channel name should contain table name");
-            Assertions.assertTrue(
-                    channelName.contains("testAppId"), "Channel name should contain appId");
+            org.assertj.core.api.Assertions.assertThat(channelName).doesNotContain("TEST_DB");
+            org.assertj.core.api.Assertions.assertThat(channelName).doesNotContain("TEST_SCHEMA");
+            org.assertj.core.api.Assertions.assertThat(channelName).doesNotContain("TEST_TABLE");
+            org.assertj.core.api.Assertions.assertThat(channelName).contains("testAppId");
             Assertions.assertTrue(channelName.contains("5"), "Channel name should contain taskId");
-        } catch (Exception e) {
-            Assertions.fail("Exception should not be thrown: " + e.getMessage());
         }
     }
 
     @Test
-    void testChannelNameFormatWithDifferentConfigs() {
-        // Test channel name format with different database/schema/table combinations
-        try (SnowflakeSinkServiceImpl sinkService1 =
-                        new FakeSnowflakeSinkServiceImpl(
-                                "app1",
-                                0,
-                                new Properties(),
-                                SnowflakeWriterConfig.builder().build(),
-                                SnowflakeChannelConfig.builder().build("DB1", "SCHEMA1", "TABLE1"),
-                                new FakeSinkWriterMetricGroup());
-                SnowflakeSinkServiceImpl sinkService2 =
-                        new FakeSnowflakeSinkServiceImpl(
-                                "app1",
-                                0,
-                                new Properties(),
-                                SnowflakeWriterConfig.builder().build(),
-                                SnowflakeChannelConfig.builder().build("DB2", "SCHEMA2", "TABLE2"),
-                                new FakeSinkWriterMetricGroup())) {
-
-            String channelName1 = sinkService1.getChannelName();
-            String channelName2 = sinkService2.getChannelName();
-
-            // Verify that different table configurations produce different channel names
-            Assertions.assertNotEquals(
-                    channelName1,
-                    channelName2,
-                    "Different table configurations should produce different channel names");
-
-            // Verify the expected prefix pattern for each
-            Assertions.assertTrue(
-                    channelName1.startsWith("DB1_SCHEMA1_TABLE1"),
-                    "Channel name should start with DB_SCHEMA_TABLE prefix");
-            Assertions.assertTrue(
-                    channelName2.startsWith("DB2_SCHEMA2_TABLE2"),
-                    "Channel name should start with DB_SCHEMA_TABLE prefix");
-        } catch (Exception e) {
-            Assertions.fail("Exception should not be thrown: " + e.getMessage());
-        }
-    }
-
-    @Test
-    void testChannelNameUniquePerTaskId() {
+    void testChannelNameUniquePerTaskId() throws Exception {
         // Test that different task IDs produce different channel names
         try (SnowflakeSinkServiceImpl sinkService1 =
                         new FakeSnowflakeSinkServiceImpl(
@@ -274,10 +227,10 @@ class SnowflakeSinkServiceImplTest {
                     "Different task IDs should produce different channel names");
 
             // Both should contain the same table prefix
-            Assertions.assertTrue(channelName1.contains("DB_SCHEMA_TABLE"));
-            Assertions.assertTrue(channelName2.contains("DB_SCHEMA_TABLE"));
-        } catch (Exception e) {
-            Assertions.fail("Exception should not be thrown: " + e.getMessage());
+            org.assertj.core.api.Assertions.assertThat(channelName2)
+                    .doesNotContain("DB_SCHEMA_TABLE");
+            org.assertj.core.api.Assertions.assertThat(channelName2)
+                    .doesNotContain("DB_SCHEMA_TABLE");
         }
     }
 


### PR DESCRIPTION
The service internally keeps track of the `db.schema.table` as the namespace for the channel name, and only requires the channel names for the same table namespace to be unique, e.g. `appId_index`.