### PR TITLE
Move to split reporting for number records in (insert) and out (flush)

### DIFF
--- a/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkWriter.java
+++ b/flink-connector-snowflake/src/main/java/io/deltastream/flink/connector/snowflake/sink/SnowflakeSinkWriter.java
@@ -18,7 +18,6 @@
 package io.deltastream.flink.connector.snowflake.sink;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
@@ -55,7 +54,6 @@ class SnowflakeSinkWriter<IN> implements SinkWriter<IN> {
     private final SnowflakeRowSerializationSchema<IN> serializationSchema;
 
     // internal states
-    private boolean checkpointInProgress = false;
     private final SnowflakeSinkContext sinkContext;
 
     SnowflakeSinkWriter(
@@ -95,17 +93,6 @@ class SnowflakeSinkWriter<IN> implements SinkWriter<IN> {
         }
     }
 
-    @VisibleForTesting
-    SnowflakeSinkWriter(
-            final SnowflakeSinkContext sinkContext,
-            final SnowflakeSinkService sinkService,
-            SnowflakeRowSerializationSchema<IN> serializationSchema) {
-
-        this.sinkContext = sinkContext;
-        this.serializationSchema = serializationSchema;
-        this.sinkService = sinkService;
-    }
-
     @Override
     public void write(IN element, Context context) throws IOException {
 
@@ -123,11 +110,9 @@ class SnowflakeSinkWriter<IN> implements SinkWriter<IN> {
                 endOfInput,
                 this.sinkContext.isFlushOnCheckpoint());
 
-        this.checkpointInProgress = true;
         if (this.sinkContext.isFlushOnCheckpoint() || endOfInput) {
             this.sinkService.flush();
         }
-        this.checkpointInProgress = false;
     }
 
     @Override

--- a/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImplTest.java
+++ b/flink-connector-snowflake/src/test/java/io/deltastream/flink/connector/snowflake/sink/internal/SnowflakeSinkServiceImplTest.java
@@ -507,6 +507,84 @@ class SnowflakeSinkServiceImplTest {
 
         @Override
         public OperatorIOMetricGroup getIOMetricGroup() {
+            return new FakeOperatorIOMetricGroup();
+        }
+
+        @Override
+        public Counter counter(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <C extends Counter> C counter(String name, C counter) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <H extends Histogram> H histogram(String name, H histogram) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <M extends Meter> M meter(String name, M meter) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MetricGroup addGroup(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MetricGroup addGroup(String key, String value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String[] getScopeComponents() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getAllVariables() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getMetricIdentifier(String metricName) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getMetricIdentifier(String metricName, CharacterFilter filter) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class FakeOperatorIOMetricGroup implements OperatorIOMetricGroup {
+
+        @Override
+        public Counter getNumRecordsInCounter() {
+            return new SimpleCounter();
+        }
+
+        @Override
+        public Counter getNumRecordsOutCounter() {
+            return new SimpleCounter();
+        }
+
+        @Override
+        public Counter getNumBytesInCounter() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Counter getNumBytesOutCounter() {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
Separate the reporting for number of records inserted and committed with the Snowflake service to have a better visibility into how the records provided to the sink are progressing with the external service.

- implemented records in/out in Snowflake service implementation
- Cleaned up legacy error reporting and flush marker